### PR TITLE
Convert gog path

### DIFF
--- a/src/cli/extract.cpp
+++ b/src/cli/extract.cpp
@@ -179,7 +179,7 @@ public:
 	
 	bool has_entry() const { return entry_ != NULL; }
 	const Entry & entry() const { return *entry_; }
-	const std::string & path() const { return gx_ ? gx_->file->path :  path_; }
+	const std::string & path() const { return path_; }
 	boost::uint64_t offset() const { return gx_ ? gx_->offset : 0; }
 	bool implied() const { return implied_; }
 	bool has_gxchunk() const { return gx_ != NULL; }
@@ -919,7 +919,7 @@ void process_file(const fs::path & file, const extract_options & o) {
 //				std::cout << "skpped\n";
 	                        continue;
 		        }
-			path = ch->file->path;
+			path = o.filenames.convert(ch->file->path);
 		}
 
 		std::string internal_path = boost::algorithm::to_lower_copy(path);


### PR DESCRIPTION
This solves the main issues I was having with the gogextract branch. See https://github.com/immi101/innoextract/commit/aacc59f07ae3844efd27e8368a1c44e858a940db#commitcomment-28812211 and my other commit comments for more information.

This is a hack. It certainly introduces new errors because it will expand variables in gog path, however, it still fixes more than it breaks. Having a variable name in the gog path is probably unlikely anyway, so this is a temporary compromise.

By using the conversion function, the `-L` switch works correctly. Furthermore the path seperators are modified correctly, so the directory tree is now correct on Linux.

---

Motivation: [This change is necessary for OpenSWE1R](https://github.com/OpenSWE1R/openswe1r/wiki/Getting-Started#option-3-installing-from-gogcom). Star Wars Racer was released on gog.com yesterday and is still prominently displayed on their website. Quick merge would be preferable so we can use the current hype to attract more developers.